### PR TITLE
Fixing broken line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Authors are invited to submit unpublished, original work with a minimum of 6 pag
 - Zhao Zhang (co-chair), TACC, USA
 - Weijia Xu (proceeding chair), TACC, USA
 - Takuya Akiba, Preferred Networks, Japan
-Thomas S. Brettin, ANL, USA
+- Thomas S. Brettin, ANL, USA
 - Erich Elsen, DeepMind, USA
 - Song Feng, IBM Research, USA
 - Boris Ginsburg, Nvidia, USA
-Torsten Hoefler, ETH, Switzerland
+- Torsten Hoefler, ETH, Switzerland
 - Jessy Li, UT Austin, USA
 - Peter Messmer, Nvidia, USA
 - Damian Podareanu, SURFsara, Netherlands


### PR DESCRIPTION
Currently, some parts of the PC member list is broken as follows:

![image](https://user-images.githubusercontent.com/469803/52840220-ea955f00-313b-11e9-952b-62ee2e4c1886.png)

![image](https://user-images.githubusercontent.com/469803/52840229-f41ec700-313b-11e9-913c-caeea40d03cc.png)
